### PR TITLE
モバイルのときとそうでないときでレイアウトを変更するように修正

### DIFF
--- a/shanari-shanari-fe/src/app/layout.tsx
+++ b/shanari-shanari-fe/src/app/layout.tsx
@@ -33,16 +33,16 @@ export default function RootLayout({
       <AdScript></AdScript>
       <body className={`${inter.variable} ${noto.variable}`}>
         <Header></Header>
-        {/* レイアウトを5分割して1:3:1の比率で利用する */}
-        <div className="grid grid-cols-5 gap-4">
+        {/* モバイルでないときはレイアウトを5分割して1:3:1の比率で利用する */}
+        <div className="md:flex flex-row">
           {/* Ad左 */}
-          <div className="...">
+          <div className="basis-1/5">
             <AdSense slot={slot}></AdSense>
           </div>
           {/* メインコンテンツ */}
-          <div className="col-span-3">{children}</div>
+          <div className="basis-3/5">{children}</div>
           {/* Ad右 */}
-          <div className="...">
+          <div className="basis-1/5">
             <AdSense slot={slot}></AdSense>
           </div>
         </div>


### PR DESCRIPTION
#20 の修正を実施
モバイルのときは縦型配置にし、デスクトップのときは両端に広告を出すように修正