### PR TITLE
何らかのプラットフォームからのアクセスのみコンテンツを表示するように修正

### DIFF
--- a/shanari-shanari-fe/src/app/page.tsx
+++ b/shanari-shanari-fe/src/app/page.tsx
@@ -5,27 +5,29 @@ import logger from "@/libs/util/logger";
 import { headers } from "next/headers";
 
 const Page = async () => {
-  // 調査用ログ
+  // 何らかのプラットフォームからのアクセスのみコンテンツを表示する (#44対策)
   const platform = headers().get("sec-ch-ua-platform");
   logger.info(`sec-ch-ua-platform: ${platform}`);
+  if (platform != null) {
+    // コンテンツ一覧を取得
+    const array_obj_contents = await FetchContentConfs("public/");
+    logger.info("Got array_obj_contents");
+    logger.info({ msg: array_obj_contents });
 
-  // コンテンツ一覧を取得
-  const array_obj_contents = await FetchContentConfs("public/");
-  logger.info("Got array_obj_contents");
-  logger.info({ msg: array_obj_contents });
-
-  // カード一覧を取得
-  const array_cards = await FetchCardConfs(
-    "public/",
-    array_obj_contents,
-    Number(process.env.TOPCUT_TOP)
-  );
-
-  return (
-    <main>
-      <Top contents={array_cards}></Top>
-    </main>
-  );
+    // カード一覧を取得
+    const array_cards = await FetchCardConfs(
+      "public/",
+      array_obj_contents,
+      Number(process.env.TOPCUT_TOP)
+    );
+    return (
+      <main>
+        <Top contents={array_cards}></Top>
+      </main>
+    );
+  } else {
+    return <main> No Platform </main>;
+  }
 };
 
 // SSRを強制する


### PR DESCRIPTION
ヘッダー情報から`sec-ch-ua-platform`を確認して、nullでなければコンテンツを表示するようにする
→GKEのMonitoringからのアクセスは上記がnullのため、GCSへアクセスさせなくてよくなる